### PR TITLE
fix tagging error in ME requester recipe

### DIFF
--- a/src/main/resources/data/merequester/recipes/requester.json
+++ b/src/main/resources/data/merequester/recipes/requester.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "e": {
-      "tag": "forge:ingots/iron"
+      "tag": "c:iron_ingots"
     },
     "i": {
       "tag": "ae2:interface"
@@ -19,7 +19,7 @@
       "item": "ae2:engineering_processor"
     },
     "c": {
-      "tag": "forge:ingots/copper"
+      "tag": "c:iron_ingots"
     },
     "s": {
       "item": "minecraft:amethyst_shard"

--- a/src/main/resources/data/merequester/recipes/requester.json
+++ b/src/main/resources/data/merequester/recipes/requester.json
@@ -19,7 +19,7 @@
       "item": "ae2:engineering_processor"
     },
     "c": {
-      "tag": "c:iron_ingots"
+      "tag": "c:copper_ingots"
     },
     "s": {
       "item": "minecraft:amethyst_shard"


### PR DESCRIPTION
## Proposed Changes
-the `forge` namespace is unlikely to exist in a fabric environment-- the `c` namespace is used for interop on fabric
