### PR TITLE
Fix crafting jobs appearing on other grids

### DIFF
--- a/src/main/java/com/almostreliable/merequester/requester/status/MissingState.java
+++ b/src/main/java/com/almostreliable/merequester/requester/status/MissingState.java
@@ -13,13 +13,6 @@ public class MissingState implements StatusState {
 
     @Override
     public StatusState handle(RequesterBlockEntity host, int slot) {
-        // re-run the crafting job plan to see if we are still missing ingredients
-        if (simulatedPlanState != null) {
-            var planSim = simulatedPlanState.handle(host, slot);
-            simulatedPlanState = null;
-            return planSim;
-        }
-
         var idleSim = StatusState.IDLE.handle(host, slot);
         if (idleSim == StatusState.IDLE || idleSim == StatusState.EXPORT) {
             // idle simulation returning idle means a request is no
@@ -30,14 +23,7 @@ public class MissingState implements StatusState {
         }
 
         // idle sim returned that we can request
-        var requestSim = StatusState.REQUEST.handle(host, slot);
-        if (requestSim == StatusState.IDLE) {
-            return StatusState.IDLE;
-        }
-
-        // request sim returned that we can start planning
-        simulatedPlanState = (PlanState) requestSim;
-        return this;
+        return PlanState.BuildPlan(host, slot, true);
     }
 
     @Override

--- a/src/main/java/com/almostreliable/merequester/requester/status/MissingState.java
+++ b/src/main/java/com/almostreliable/merequester/requester/status/MissingState.java
@@ -3,11 +3,7 @@ package com.almostreliable.merequester.requester.status;
 import appeng.api.networking.ticking.TickRateModulation;
 import com.almostreliable.merequester.requester.RequesterBlockEntity;
 
-import javax.annotation.Nullable;
-
 public class MissingState implements StatusState {
-
-    @Nullable private PlanState simulatedPlanState;
 
     MissingState() {}
 

--- a/src/main/java/com/almostreliable/merequester/requester/status/RequestState.java
+++ b/src/main/java/com/almostreliable/merequester/requester/status/RequestState.java
@@ -9,22 +9,8 @@ public class RequestState implements StatusState {
     RequestState() {}
 
     @Override
-    public StatusState handle(RequesterBlockEntity owner, int index) {
-        var amountToCraft = owner.getStorageManager().computeAmountToCraft(index);
-        if (amountToCraft <= 0) return StatusState.IDLE;
-        var key = owner.getRequests().getKey(index);
-
-        var future = owner.getMainNodeGrid()
-            .getCraftingService()
-            .beginCraftingCalculation(
-                owner.getLevel(),
-                owner::getActionSource,
-                key,
-                amountToCraft,
-                CalculationStrategy.CRAFT_LESS
-            );
-
-        return new PlanState(future);
+    public StatusState handle(RequesterBlockEntity host, int slot) {
+        return PlanState.BuildPlan(host, slot, false);
     }
 
     @Override


### PR DESCRIPTION
Prevent crafting jobs ending up on the wrong grid when there are requests with missing ingredients on multiple grids. This was happening because MissingState was being used as a singleton but had request-specific state.

Show missing ingredients state more consistently.

## Issue Reference
https://github.com/AlmostReliable/merequester/issues/21

## Proposed Changes
Move state out of MissingState and add a field to PlanState so that "Missing Ingredients" won't disappear until we successfully transition to LinkState.
