### PR TITLE
add dummy host interface for terminal implementations

### DIFF
--- a/src/main/java/com/almostreliable/merequester/terminal/RequesterTerminalHost.java
+++ b/src/main/java/com/almostreliable/merequester/terminal/RequesterTerminalHost.java
@@ -1,0 +1,3 @@
+package com.almostreliable.merequester.terminal;
+
+public interface RequesterTerminalHost {}

--- a/src/main/java/com/almostreliable/merequester/terminal/RequesterTerminalMenu.java
+++ b/src/main/java/com/almostreliable/merequester/terminal/RequesterTerminalMenu.java
@@ -32,7 +32,7 @@ import java.util.Map;
 public class RequesterTerminalMenu extends AbstractRequesterMenu {
 
     public static final MenuType<RequesterTerminalMenu> TYPE = MenuTypeBuilder
-        .create(RequesterTerminalMenu::new, RequesterTerminalPart.class)
+        .create(RequesterTerminalMenu::new, RequesterTerminalHost.class)
         .build(Utils.getRL(MERequester.TERMINAL_ID));
 
     private final Long2ObjectOpenHashMap<RequestTracker> byId = new Long2ObjectOpenHashMap<>();

--- a/src/main/java/com/almostreliable/merequester/terminal/RequesterTerminalPart.java
+++ b/src/main/java/com/almostreliable/merequester/terminal/RequesterTerminalPart.java
@@ -19,7 +19,7 @@ import appeng.parts.reporting.PatternAccessTerminalPart;
 /**
  * yoinked from {@link PatternAccessTerminalPart}
  */
-public class RequesterTerminalPart extends AbstractDisplayPart {
+public class RequesterTerminalPart extends AbstractDisplayPart implements RequesterTerminalHost {
 
     @PartModels
     private static final ResourceLocation MODEL_OFF = Utils.getRL(String.format("part/%s_off", MERequester.TERMINAL_ID));


### PR DESCRIPTION
## Proposed Changes
In order for add-ons to more easily provide their own implementation of a Requester Terminal (e.g. AE2WTLib with a Wireless Requester Terminal, or Fullblock Energistics with a full-block Requester Terminal), this PR adds a common "host" interface to use for terminal implementations.

While the interface itself is effectively completely empty, due to the current part implementation itself not doing anything special (other than opening the menu which does all the heavy lifting instead), it means that the menu can be built against this host interface now rather than the specific part implementation, allowing add-ons to re-use the same menu without needing to create a duplicate Requester Terminal menu.
