### PR TITLE
Recompute cached resource amounts when StackWatcher updates

### DIFF
--- a/src/main/java/com/almostreliable/merequester/requester/StorageManager.java
+++ b/src/main/java/com/almostreliable/merequester/requester/StorageManager.java
@@ -34,6 +34,9 @@ public class StorageManager implements IStorageWatcherNode, TagSerializable<Comp
     public void updateWatcher(IStackWatcher newWatcher) {
         stackWatcher = newWatcher;
         resetWatcher();
+        for(int i = 0; i < storages.length; i++){
+            computeKnownAmount(i);
+        }
     }
 
     @Override

--- a/src/main/java/com/almostreliable/merequester/requester/StorageManager.java
+++ b/src/main/java/com/almostreliable/merequester/requester/StorageManager.java
@@ -34,7 +34,7 @@ public class StorageManager implements IStorageWatcherNode, TagSerializable<Comp
     public void updateWatcher(IStackWatcher newWatcher) {
         stackWatcher = newWatcher;
         resetWatcher();
-        for(int i = 0; i < storages.length; i++){
+        for (var i = 0; i < storages.length; i++) {
             computeKnownAmount(i);
         }
     }


### PR DESCRIPTION
When a requester is connected to a new network, the item/fluid counts it has cached are not updated.

In particular, this is exposed when you disconnect your requesters (e.g., using a toggle bus) to disable them.
You have over the request amount before disconnecting. Then you use some. Now, when you reconnect them, it thinks it still has enough and does not request more.

## Proposed Changes
Added a recompuation of the cached item/fluid amounts when a new watcher is attached using updateWatcher.


## Additional Notes
I targeted 1.20.1-forge here because that is the version I need for the pack(s) I play.
The fix cleanly applies to all versions in this repo, so it can be cherry-picked over.
I also have branches for all versions in my fork if that helps.
I know you don't really support this version anymore, but I would really appreciate an official build.