### PR TITLE
fix request slots not accepting ghost items from EMI

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ forgeVersion = 47.1.3
 forgeRecipeViewer = jei
 
 # Mod Dependencies
-aeVersion = 15.0.6-beta
+aeVersion = 15.4.10
 reiVersion = 12.0.625
 jeiVersion = 15.2.0.22
 

--- a/src/main/java/com/almostreliable/merequester/client/RequestSlot.java
+++ b/src/main/java/com/almostreliable/merequester/client/RequestSlot.java
@@ -5,6 +5,7 @@ import com.almostreliable.merequester.Utils;
 import com.almostreliable.merequester.client.abstraction.RequestDisplay;
 import com.almostreliable.merequester.client.abstraction.RequesterReference;
 import com.almostreliable.merequester.mixin.accessors.SlotMixin;
+import com.almostreliable.merequester.platform.Platform;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
@@ -73,5 +74,15 @@ public class RequestSlot extends FakeSlot {
 
     public void setLocked(boolean locked) {
         isLocked = locked;
+    }
+    
+    @Override
+    public boolean canSetFilterTo(ItemStack stack) {
+        return isLocked ? false : super.canSetFilterTo(stack);
+    }
+
+    @Override
+    public void setFilterTo(ItemStack stack) {
+        Platform.sendDragAndDrop(requesterReference.getRequesterId(), slot, stack);
     }
 }


### PR DESCRIPTION
ME Requester stopped accepting drag-and-drop from ghost items from EMI.
Changes in Applied Energistics 2 [Add native EMI support for Forge 1.20.1. (#8659)](https://github.com/AppliedEnergistics/Applied-Energistics-2/commit/40f32adcae9502ae3cba9316b207a0ef85417dbb) seems to be the culprit.
I've isolated the issue to the `canSetFilterTo` and `setFilterTo` methods seen at
https://github.com/AppliedEnergistics/Applied-Energistics-2/blob/forge/1.20.1/src/main/java/appeng/menu/slot/FakeSlot.java#L65

## Proposed Changes
Update the `aeVersion` dependency to release [15.4.10](https://github.com/AppliedEnergistics/Applied-Energistics-2/releases/tag/forge%2Fv15.4.10) and add simple overrides to `FakeSlot` methods in `RequestSlot`.
This should fix drag-and-drop ghost item stacks from EMI being ignored.

## Additional Context
I targeted 1.20.1-forge here because that is the version I need for the pack I play.
I saw you were willing to do critical bug fixes, so hopefully you can include this fix as well.

Thank you!!