### PR TITLE
Allow up to three decimal places for fluids amounts

### DIFF
--- a/src/main/java/com/almostreliable/merequester/client/widgets/NumberField.java
+++ b/src/main/java/com/almostreliable/merequester/client/widgets/NumberField.java
@@ -91,7 +91,7 @@ public class NumberField extends ConfirmableTextField {
 
         var possibleValue = getValueInternal();
         if (possibleValue.isPresent()) {
-            if (possibleValue.get().scale() > 0) {
+            if (possibleValue.get().scale() > (isFluid ? 3 : 0)) {
                 validationErrors.add(Utils.translate("tooltip", "whole_number"));
             } else {
                 var value = convertToExternalValue(possibleValue.get());


### PR DESCRIPTION
The ME Requester work perfectly fine when configured with millibucket amounts of fluid, but the number field unconditionally marks them as invalid because of the decimal places. This logic makes sense for items only, but fluids quantities are valid down to 0.001B (1mB).

## Issue Reference
Fixes issue #41.

## Proposed Changes
Add a ternary for the number of decimal places allowed. Default is kept at zero for items, but conditionally set to three for fluids (increments of 1mB) using the existing `NumberField` member `isFluid`.

This is how that looks in-game;
<img width="412" height="266" alt="2026-06-15 01-51-53" src="https://github.com/user-attachments/assets/8d48e03d-2d1e-4f98-b4ef-9c87a0f4a4c5" />
<img width="418" height="267" alt="2026-06-15 01-54-16" src="https://github.com/user-attachments/assets/17efe690-8e4d-4f4e-bd31-ff723e66f2e1" />



## Additional Context
I targeted 1.20.1-forge here because that is the version the pack I play (Star Technology) is based on.
The fix cleanly applies to all versions in this repo, so it can be cherry-picked over.
I know this fix isn't critical, but I was hoping you'd at least consider adding this QoL fix.

Thank you!!